### PR TITLE
fix(prepare_source): use Salsa debian branch instead of apt_src

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,2 +1,2 @@
-apt_src refpolicy
+git_src --branch debian https://salsa.debian.org/selinux-team/refpolicy.git
 import_upstream_patches


### PR DESCRIPTION
## Summary

- `refpolicy` was removed from Debian testing on 2026-05-18 (blocked from migrating due to 5-day aging policy), causing `apt_src refpolicy` to fail with "cannot determine candidate version"
- Switch to `git_src` from `salsa.debian.org/selinux-team/refpolicy.git` (`debian` branch) which always has the latest Debian packaging regardless of testing migration status

## Reference

- Debian tracker: https://tracker.debian.org/pkg/refpolicy
- Failing CI run: https://github.com/gardenlinux/package-refpolicy/actions/runs/26007484293